### PR TITLE
feat: allow throwing from event filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# race-event <!-- omit in toc -->
+# race-event
 
 [![codecov](https://img.shields.io/codecov/c/github/achingbrain/race-event.svg?style=flat-square)](https://codecov.io/gh/achingbrain/race-event)
 [![CI](https://img.shields.io/github/actions/workflow/status/achingbrain/race-event/js-test-and-release.yml?branch=main\&style=flat-square)](https://github.com/achingbrain/race-event/actions/workflows/js-test-and-release.yml?query=branch%3Amain)
@@ -7,13 +7,28 @@
 
 # About
 
+<!--
+
+!IMPORTANT!
+
+Everything in this README between "# About" and "# Install" is automatically
+generated and will be overwritten the next time the doc generator is run.
+
+To make changes to this section, please update the @packageDocumentation section
+of src/index.js or src/index.ts
+
+To experiment with formatting, please run "npm run docs" from the root of this
+repo and examine the changes made.
+
+-->
+
 Race an event against an AbortSignal, taking care to remove any event
 listeners that were added.
 
-## Example
+## Example - Getting started
 
 ```TypeScript
-const { raceEvent } = require('race-event')
+import { raceEvent } from 'race-event'
 
 const controller = new AbortController()
 const emitter = new EventTarget()
@@ -29,6 +44,70 @@ setTimeout(() => {
 
 // throws an AbortError
 const resolve = await raceEvent(emitter, 'event', controller.signal)
+```
+
+## Example - Customising the thrown AbortError
+
+The error message and `.code` property of the thrown `AbortError` can be
+specified by passing options:
+
+```TypeScript
+import { raceEvent } from 'race-event'
+
+const controller = new AbortController()
+const emitter = new EventTarget()
+
+setTimeout(() => {
+  controller.abort()
+}, 500)
+
+// throws a Error: Oh no!
+const resolve = await raceEvent(emitter, 'event', controller.signal, {
+  errorMessage: 'Oh no!',
+  errorCode: 'ERR_OH_NO'
+})
+```
+
+## Example - Only resolving on specific events
+
+Where multiple events with the same type are emitted, a `filter` function can
+be passed to only resolve on one of them:
+
+```TypeScript
+import { raceEvent } from 'race-event'
+
+const controller = new AbortController()
+const emitter = new EventTarget()
+
+// throws a Error: Oh no!
+const resolve = await raceEvent(emitter, 'event', controller.signal, {
+  filter: (evt: Event) => {
+    return evt.detail.foo === 'bar'
+  }
+})
+```
+
+## Example - Terminating early by throwing from the filter
+
+You can cause listening for the event to cease and all event listeners to be
+removed by throwing from the filter:
+
+```TypeScript
+import { raceEvent } from 'race-event'
+
+const controller = new AbortController()
+const emitter = new EventTarget()
+
+// throws Error: Cannot continue
+const resolve = await raceEvent(emitter, 'event', controller.signal, {
+  filter: (evt) => {
+    if (...reasons) {
+      throw new Error('Cannot continue')
+    }
+
+    return true
+  }
+})
 ```
 
 # Install

--- a/package.json
+++ b/package.json
@@ -137,6 +137,6 @@
     "docs": "aegir docs"
   },
   "devDependencies": {
-    "aegir": "^41.0.0"
+    "aegir": "^42.2.4"
   }
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -95,4 +95,19 @@ describe('race-event', () => {
       }
     })).to.eventually.equal(otherEvent)
   })
+
+  it('should reject if the filter throws', async () => {
+    const err = new Error('Urk!')
+    const controller = new AbortController()
+
+    setTimeout(() => {
+      emitter.dispatchEvent(event)
+    }, 10)
+
+    await expect(raceEvent<CustomEvent<string>>(emitter, eventName, controller.signal, {
+      filter: () => {
+        throw err
+      }
+    })).to.eventually.be.rejectedWith(err)
+  })
 })


### PR DESCRIPTION
To allow stopping listening for further events without being a success, propagate errors thrown from the event filter.