### PR TITLE
feat: reject on configurable error event

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ setTimeout(() => {
 const resolve = await raceEvent(emitter, 'event', controller.signal)
 ```
 
+## Example - Aborting the promise with an error event
+
+```TypeScript
+import { raceEvent } from 'race-event'
+
+const emitter = new EventTarget()
+
+setTimeout(() => {
+  emitter.dispatchEvent(new CustomEvent('failure', {
+    detail: new Error('Oh no!')
+  }))
+}, 1000)
+
+// throws 'Oh no!' error
+const resolve = await raceEvent(emitter, 'success', AbortSignal.timeout(5000), {
+  errorEvent: 'failure'
+})
+```
+
 ## Example - Customising the thrown AbortError
 
 The error message and `.code` property of the thrown `AbortError` can be

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -110,4 +110,19 @@ describe('race-event', () => {
       }
     })).to.eventually.be.rejectedWith(err)
   })
+
+  it('should reject via an error event', async () => {
+    const err = new Error('Urk!')
+    const controller = new AbortController()
+
+    setTimeout(() => {
+      emitter.dispatchEvent(new CustomEvent<Error>('custom-error', {
+        detail: err
+      }))
+    }, 10)
+
+    await expect(raceEvent<CustomEvent<string>>(emitter, eventName, controller.signal, {
+      errorEvent: 'custom-error'
+    })).to.eventually.be.rejectedWith(err)
+  })
 })


### PR DESCRIPTION
Allow rejecting the returned promise when an error event is emitted by the emitter.

The `.detail` field of the event will be used as the rejection reason.