### PR TITLE
feat: abort on error by default

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -116,6 +116,20 @@ describe('race-event', () => {
     const controller = new AbortController()
 
     setTimeout(() => {
+      emitter.dispatchEvent(new CustomEvent<Error>('error', {
+        detail: err
+      }))
+    }, 10)
+
+    await expect(raceEvent<CustomEvent<string>>(emitter, eventName, controller.signal))
+      .to.eventually.be.rejectedWith(err)
+  })
+
+  it('should reject via an custom error event', async () => {
+    const err = new Error('Urk!')
+    const controller = new AbortController()
+
+    setTimeout(() => {
       emitter.dispatchEvent(new CustomEvent<Error>('custom-error', {
         detail: err
       }))


### PR DESCRIPTION
Defaults the `errorEvent` option to `"error"` to cater for the most common event pattern.