### PR TITLE
feat: accept error option

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,5 +139,8 @@
   },
   "devDependencies": {
     "aegir": "^47.0.20"
+  },
+  "dependencies": {
+    "abort-error": "^1.0.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,20 +109,7 @@
  * ```
  */
 
-/**
- * An abort error class that extends error
- */
-export class AbortError extends Error {
-  public type: string
-  public code: string | string
-
-  constructor (message?: string, code?: string) {
-    super(message ?? 'The operation was aborted')
-    this.type = 'aborted'
-    this.name = 'AbortError'
-    this.code = code ?? 'ABORT_ERR'
-  }
-}
+import { AbortError } from "abort-error"
 
 export interface RaceEventOptions<T> {
   /**
@@ -145,6 +132,12 @@ export interface RaceEventOptions<T> {
   errorEvent?: string
 
   /**
+   * If the 'errorEvent' option has been passed, and the emitted event has no
+   * `.detail` field, reject the promise with this error instead.
+   */
+  error?: Error
+
+  /**
    * When multiple events with the same name may be emitted, pass a filter
    * function here to allow ignoring ones that should not cause the returned
    * promise to resolve.
@@ -157,7 +150,13 @@ export interface RaceEventOptions<T> {
  */
 export async function raceEvent <T> (emitter: EventTarget, eventName: string, signal?: AbortSignal, opts?: RaceEventOptions<T>): Promise<T> {
   // create the error here so we have more context in the stack trace
-  const error = new AbortError(opts?.errorMessage, opts?.errorCode)
+  const error = new AbortError(opts?.errorMessage)
+
+  if (opts?.errorCode != null) {
+    // @ts-expect-error not a field of AbortError
+    error.code = opts.errorCode
+  }
+
   const errorEvent = opts?.errorEvent ?? 'error'
 
   if (signal?.aborted === true) {
@@ -188,7 +187,7 @@ export async function raceEvent <T> (emitter: EventTarget, eventName: string, si
 
     const errorEventListener = (evt: any): void => {
       removeListeners()
-      reject(evt.detail)
+      reject(evt.detail ?? opts?.error ?? new Error(`The "${opts?.errorEvent}" event was emitted but the event had no '.detail' field. Pass an 'error' option to race-event to change this message.`))
     }
 
     const abortListener = (): void => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@
  * ```
  */
 
-import { AbortError } from "abort-error"
+import { AbortError } from 'abort-error'
 
 export interface RaceEventOptions<T> {
   /**

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -26,7 +26,7 @@ describe('race-event', () => {
     const controller = new AbortController()
     controller.abort()
 
-    await expect(raceEvent(emitter, eventName, controller.signal)).to.eventually.be.rejected().with.property('code', 'ABORT_ERR')
+    await expect(raceEvent(emitter, eventName, controller.signal)).to.eventually.be.rejected().with.property('name', 'AbortError')
   })
 
   it('should have default error fields', async () => {
@@ -35,9 +35,7 @@ describe('race-event', () => {
 
     const err = await raceEvent(emitter, eventName, controller.signal).catch(err => err)
 
-    expect(err).to.have.property('type', 'aborted')
     expect(err).to.have.property('name', 'AbortError')
-    expect(err).to.have.property('code', 'ABORT_ERR')
   })
 
   it('should have override error fields', async () => {
@@ -64,7 +62,7 @@ describe('race-event', () => {
       controller.abort()
     }, 100)
 
-    await expect(raceEvent(emitter, eventName, controller.signal)).to.eventually.be.rejected().with.property('code', 'ABORT_ERR')
+    await expect(raceEvent(emitter, eventName, controller.signal)).to.eventually.be.rejected().with.property('name', 'AbortError')
   })
 
   it('should resolve after a delay', async () => {


### PR DESCRIPTION
To handle the case where an `error` event is emitted with no or an empty `.detail` field, allow passing a default error to reject the promise with.